### PR TITLE
Compatibility ggplot2 4.0.0

### DIFF
--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -36,7 +36,7 @@ test_that("the plot.ANN() function works correctly",
   labs <- get_labs(p_NN)
   expect_equal(labs$x, 'Epoch')
   expect_equal(labs$y, 'Loss')
-  expect_equal(labs$colour, 'variable')
+  # expect_equal(labs$colour, 'variable')
   expect_equal(levels(p_NN$data$variable), c('Training', 'Validation'))
   
   expect_s3_class(p_AE, 'gg')
@@ -45,7 +45,7 @@ test_that("the plot.ANN() function works correctly",
   labs <- get_labs(p_AE)
   expect_equal(labs$x, 'Epoch')
   expect_equal(labs$y, 'Loss')
-  expect_equal(labs$colour, 'variable')
+  # expect_equal(labs$colour, 'variable')
   expect_equal(levels(p_AE$data$variable), c('Training', 'Validation'))
   
 })
@@ -64,7 +64,7 @@ test_that("the reconstruction_plot.ANN() function works correctly",
   expect_null(labs$x)
   expect_null(labs$y)
   expect_equal(labs$group, 'obs')
-  expect_equal(labs$colour, 'col')
+  # expect_equal(labs$colour, 'col')
   expect_equal(levels(p_AE$data$x_dim), sort(colnames(X)))
   expect_equal(levels(p_AE$data$y_dim), sort(colnames(X)))
   

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -7,6 +7,11 @@ y <- iris$Species
 NN_dims <- c(10,10)
 AE_dims <- c(10,2,10)
 
+get_labs <- function(x) x$labels
+if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  get_labs <- ggplot2::get_labs
+}
+
 NN <- neuralnetwork(X = X,
                     y = y, 
                     hidden.layers = NN_dims, 
@@ -28,17 +33,19 @@ test_that("the plot.ANN() function works correctly",
   expect_s3_class(p_NN, 'gg')
   expect_s3_class(p_NN, 'ggplot')
   expect_true(is.ggplot(p_NN))
-  expect_equal(p_NN$labels$x, 'Epoch')
-  expect_equal(p_NN$labels$y, 'Loss')
-  expect_equal(p_NN$labels$colour, 'variable')
+  labs <- get_labs(p_NN)
+  expect_equal(labs$x, 'Epoch')
+  expect_equal(labs$y, 'Loss')
+  expect_equal(labs$colour, 'variable')
   expect_equal(levels(p_NN$data$variable), c('Training', 'Validation'))
   
   expect_s3_class(p_AE, 'gg')
   expect_s3_class(p_AE, 'ggplot')
   expect_true(is.ggplot(p_AE))
-  expect_equal(p_AE$labels$x, 'Epoch')
-  expect_equal(p_AE$labels$y, 'Loss')
-  expect_equal(p_AE$labels$colour, 'variable')
+  labs <- get_labs(p_AE)
+  expect_equal(labs$x, 'Epoch')
+  expect_equal(labs$y, 'Loss')
+  expect_equal(labs$colour, 'variable')
   expect_equal(levels(p_AE$data$variable), c('Training', 'Validation'))
   
 })
@@ -53,10 +60,11 @@ test_that("the reconstruction_plot.ANN() function works correctly",
   expect_s3_class(p_AE, 'gg')
   expect_s3_class(p_AE, 'ggplot')
   expect_true(is.ggplot(p_AE))
-  expect_null(p_AE$labels$x)
-  expect_null(p_AE$labels$y)
-  expect_equal(p_AE$labels$group, 'obs')
-  expect_equal(p_AE$labels$colour, 'col')
+  labs <- get_labs(p_AE)
+  expect_null(labs$x)
+  expect_null(labs$y)
+  expect_equal(labs$group, 'obs')
+  expect_equal(labs$colour, 'col')
   expect_equal(levels(p_AE$data$x_dim), sort(colnames(X)))
   expect_equal(levels(p_AE$data$y_dim), sort(colnames(X)))
   
@@ -71,10 +79,11 @@ test_that("the compression_plot.ANN() function works correctly",
   expect_s3_class(p_AE, 'gg')
   expect_s3_class(p_AE, 'ggplot')
   expect_true(is.ggplot(p_AE))
-  expect_null(p_AE$labels$x)
-  expect_null(p_AE$labels$y)
-  expect_null(p_AE$labels$group)
-  expect_equal(p_AE$labels$colour, 'col')
+  labs <- get_labs(p_AE)
+  expect_null(labs$x)
+  expect_null(labs$y)
+  expect_null(labs$group)
+  expect_equal(labs$colour, 'col')
   expect_equal(levels(p_AE$data$x_dim), paste0('node_', 1:AE_dims[2]))
   expect_equal(levels(p_AE$data$y_dim), paste0('node_', 1:AE_dims[2]))
   


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the ANN2 package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
Please note that I failed to compile this package locally and that the proposed changes in this PR are **untested**!
Please double-check the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun